### PR TITLE
fix typo for undefined variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ output = pyscryptfirebase.encrypt(
     memcost,
     password
 )
-encoded_output = base64.b64encode(result)
+encoded_output = base64.b64encode(output)
 print(encoded_output)
 ```
 


### PR DESCRIPTION
The value from the 'encrypt' function in the README file is being sent to the 'output' variable. Undefined variable 'result' is being sent as a parameter when using the 'b64encode' function. Replaced 'result' variable with 'output'.